### PR TITLE
Player join events

### DIFF
--- a/pymine/api/register.py
+++ b/pymine/api/register.py
@@ -1,4 +1,6 @@
 import asyncio
+from pymine.net.packets.login.login import LoginSuccess
+from pymine.net.packets.play.player import PlayJoinGame
 
 from pymine.api.events import PacketEvent, ServerStartEvent, ServerStopEvent
 from pymine.types.abc import AbstractWorldGenerator, AbstractPlugin
@@ -49,6 +51,12 @@ class Register:
             return func
 
         return deco
+
+    def on_login_success(self, func):
+        return PacketEvent(func, STATES.encode("login"), LoginSuccess.id)
+
+    def on_join(self, func):
+        return PacketEvent(func, STATES.encode("play"), PlayJoinGame.id)
 
     def on_server_start(self, func):
         if not asyncio.iscoroutinefunction(func):

--- a/pymine/logic/handle/login.py
+++ b/pymine/logic/handle/login.py
@@ -86,10 +86,7 @@ async def encrypted_login(stream: Stream, packet: Packet) -> Stream:
     state = STATES.encode("login")
     await server.send_packet(stream, success_packet)
 
-    if server.api.register._on_packet[state].get(success_packet.id) is None:
-        #is warning usefull since only plugin are suppose to use this event?
-        server.console.warn(f"No packet handler found for packet: 0x{success_packet.id:02X} {type(success_packet).__name__}")
-    else:
+    if not (server.api.register._on_packet[state].get(success_packet.id) is None):
         for handler in server.api.register._on_packet[state][success_packet.id].values():
             server.console.debug(handler)
             await handler(stream, success_packet)

--- a/pymine/logic/join.py
+++ b/pymine/logic/join.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 import asyncio
-from pymine.data.states import STATES
 import random
 import time
 import uuid
@@ -29,6 +28,7 @@ from pymine.types.chat import Chat
 import pymine.types.nbt as nbt
 
 from pymine.data.default_nbt.dimension_codec import new_dim_codec_nbt, get_dimension_data
+from pymine.data.states import STATES
 from pymine.data.recipes import RECIPES
 from pymine.data.tags import TAGS
 

--- a/pymine/logic/join.py
+++ b/pymine/logic/join.py
@@ -126,10 +126,7 @@ async def send_join_game_packet(stream: Stream, world: World, player: Player) ->
         )
     await server.send_packet(stream, join_packet,)
 
-    if server.api.register._on_packet[state].get(join_packet.id) is None:
-        #is warning usefull since only plugin are suppose to use this event?
-        server.console.warn(f"No packet handler found for packet: 0x{join_packet.id:02X} {type(join_packet).__name__}")
-    else:
+    if not (server.api.register._on_packet[state].get(join_packet.id) is None):
         for handler in server.api.register._on_packet[state][join_packet.id].values():
             await handler(stream, join_packet)
 


### PR DESCRIPTION
Add two new methodes to registery to be used by plugins.

`@on_login_success` is equivalent to `@on_packet("login", 0x02)` and both will get trigger after a successful login with the following args: the associated stream and packet.

`@on_join` is equivalent to `@on_packet("play", 0x24)` and both will get trigger after a player fully load into the world with the following args: the associated stream and packet.