### PR TITLE
[docs] Remove build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 ![quality](https://www.codefactor.io/repository/github/py-mine/pymine-server/badge)
 ![contributors](https://img.shields.io/badge/dynamic/json?color=0FAE6E&label=contributors&query=contributors.length&url=https%3A%2F%2Fraw.githubusercontent.com%2Fpy-mine%2FPyMine%2Fmain%2F.all-contributorsrc)
 ![code size](https://img.shields.io/github/languages/code-size/py-mine/PyMine?color=0FAE6E)
-![build status](https://img.shields.io/github/workflow/status/py-mine/PyMine/Python%20App?color=0FAE6E)
 ![code style](https://img.shields.io/badge/code%20style-black-000000.svg)
 
 


### PR DESCRIPTION
The build badge in the readme is broke due to [this issue](https://github.com/badges/shields/issues/8671)
![image](https://github.com/user-attachments/assets/a50d7068-f814-4a78-9bd0-944d2fd986d8)

After editing the badge to reflect the new change, it shows `no status` because the workflows are never ran
<sub> potential bug maybe? the workflows are supposed to be running </sub>
![image](https://github.com/user-attachments/assets/2211b8ae-ca45-48d1-be5a-33d47181e14e)


So i have removed the build badge as it serves no purpose.